### PR TITLE
Fix the bug that when multiple zotero plugins installed first, papersgpt can't be started

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,10 +77,10 @@
     "esbuild-plugin-wasm": "^1.0.0",
     "minimist": "^1.2.7",
     "punycode": "^2.3.0",
-    "release-it": "^15.6.0",
+    "release-it": "^17.7.0",
     "replace-in-file": "^6.3.5",
-    "typescript": "^5.0.4",
+    "typescript": "^5.6.2",
     "uglify-js": "^3.17.4",
-    "zotero-types": "^1.0.12"
+    "zotero-types": "^2.2.0"
   }
 }

--- a/src/addon.ts
+++ b/src/addon.ts
@@ -1,14 +1,15 @@
-import { ZoteroToolkit } from "zotero-plugin-toolkit";
+//import { ZoteroToolkit } from "zotero-plugin-toolkit";
 import { ColumnOptions } from "zotero-plugin-toolkit/dist/helpers/virtualizedTable";
 import hooks from "./hooks";
-//import { createZToolkit } from "./ztoolkit"
+import { createZToolkit } from "./ztoolkit"
 
 class Addon {
   public data: {
     alive: boolean;
     // Env type, see build.js
     env: "development" | "production";
-    ztoolkit: ZoteroToolkit;
+    //ztoolkit: ZoteroToolkit;
+    ztoolkit: MyToolkit;
     locale?: {
       stringBundle: any;
     };
@@ -27,8 +28,8 @@ class Addon {
     this.data = {
       alive: true,
       env: __env__,
-      ztoolkit: new ZoteroToolkit(),
-      //ztoolkit: createZToolkit(),
+      //ztoolkit: new ZoteroToolkit(),
+      ztoolkit: createZToolkit(),
     };
     this.hooks = hooks;
     this.api = {};

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,6 @@ if (!basicTool.getGlobal("Zotero")[config.addonInstance]) {
   _globalThis.Zotero_Tabs = basicTool.getGlobal("Zotero_Tabs");
   _globalThis.window = window = basicTool.getGlobal("window");
   _globalThis.URL = basicTool.getGlobal("window").URL;
-  _globalThis.setTimeout = basicTool.getGlobal("window").setTimeout;
   _globalThis.URLSearchParams = basicTool.getGlobal("window").URLSearchParams;
   _globalThis.Headers = basicTool.getGlobal("window").Headers;
   _globalThis.AbortSignal = basicTool.getGlobal("window").AbortSignal;

--- a/src/modules/Meet/papersgpt.ts
+++ b/src/modules/Meet/papersgpt.ts
@@ -435,7 +435,7 @@ export async function getSupportedLLMs(publisher2models: Map<string, ModelConfig
 				email: email,
 				token: token,
 			}),
-			timeout: 1000
+			timeout: 5000
 		}
         )
       } catch (error: any) {
@@ -483,7 +483,7 @@ export async function getSupportedLLMs(publisher2models: Map<string, ModelConfig
 	      email: email,
               token: token,
             }),
-	    timeout: 1000
+	    timeout: 2000
           }
         )
       } catch (error: any) {
@@ -502,11 +502,11 @@ export async function getSupportedLLMs(publisher2models: Map<string, ModelConfig
 
 
   if (httpRequestError) {
+      Zotero.log("request error")
       return
   }
 
   if (res?.response.Code) {
-
     if (res.response.Code != 200) {
       return
     } 

--- a/src/modules/views.ts
+++ b/src/modules/views.ts
@@ -6,6 +6,7 @@ import { help, fontFamily, defaultTags, parseTag } from "./base"
 import { getLocalModelDownloadProgress, setApiKey, getSupportedLLMs, ModelConfig, selectModel } from "./Meet/papersgpt";
 import { checkFileExist, startLocalLLMEngine, shutdownLocalLLMEngine } from "../hooks";
 
+
 const markdown = require("markdown-it")({
   breaks: true, // Convert line terminators \n to <br> tags
   xhtmlOut: true, // Use /> to close the tag, not >
@@ -1612,7 +1613,7 @@ export default class Views {
 					      Zotero.Prefs.set(`${config.addonRef}.isLicenseActivated`, true) 
 					      Zotero.Prefs.set(`${config.addonRef}.grade`, res.response.grader) 	
 
-
+                                
 					      await Zotero[config.addonInstance].views.updatePublisherModels(email, token)
 					      Zotero[config.addonInstance].views.createOrUpdateModelsContainer()
 
@@ -2832,8 +2833,9 @@ export default class Views {
   private async execTag(tag: Tag) {
     Meet.Global.input = this.inputContainer.querySelector("input")?.value as string
     this._tag = tag
-    const popunWin = new ztoolkit.ProgressWindow(tag.tag, { closeTime: -1, closeOtherProgressWindows: true })
+    const popunWin = new ztoolkit.ProgressWindow(tag.tag, { closeOnClick: true, closeTime: -1, closeOtherProgressWindows: true })
       .show()
+
     Meet.Global.popupWin = popunWin
     popunWin
       .createLine({ text: "Generating input content...", type: "default" })
@@ -3234,7 +3236,7 @@ export default class Views {
           var filename = "ChatPDFLocal"
 	  const temp = Zotero.getTempDirectory();
           filename = PathUtils.join(temp.path.replace(temp.leafName, ""), `${filename}.dmg`);
-	 
+
 	  if (await checkFileExist(filename + ".done")) {
 	      var startLocalServer = Zotero.Prefs.get(`${config.addonRef}.startLocalServer`)
               if (!startLocalServer) {
@@ -3243,8 +3245,8 @@ export default class Views {
 		  Zotero.Prefs.set(`${config.addonRef}.startLocalServer`, true)
 	          const execFunc = async() => {
 		      var email = Zotero.Prefs.get(`${config.addonRef}.email`) 
-                      var token =  Zotero.Prefs.get(`${config.addonRef}.token`) 
-                      await Zotero[config.addonInstance].views.updatePublisherModels(email, token)
+                      var token =  Zotero.Prefs.get(`${config.addonRef}.token`)
+		      await Zotero[config.addonInstance].views.updatePublisherModels(email, token)
                       Zotero[config.addonInstance].views.createOrUpdateModelsContainer()
                   }
                   window.setTimeout(execFunc, 3000)
@@ -3252,7 +3254,7 @@ export default class Views {
 	  } 
       } else {
 	  var email = Zotero.Prefs.get(`${config.addonRef}.email`) 
-          var token =  Zotero.Prefs.get(`${config.addonRef}.token`) 
+          var token =  Zotero.Prefs.get(`${config.addonRef}.token`)
 	  await Zotero[config.addonInstance].views.updatePublisherModels(email, token)
           Zotero[config.addonInstance].views.createOrUpdateModelsContainer()
       }
@@ -3299,7 +3301,8 @@ export default class Views {
     const key = "enter"
     if (Zotero.isMac) {
       const modifiers = "meta"
-      ztoolkit.Keyboard.register((ev, data) => {
+      //ztoolkit.Keyboard.register((ev, data) => {
+      ztoolkit.Shortcut.register((ev, data) => {
         if (data.type === "keyup" && data.keyboard) {
           if (data.keyboard.equals(`${modifiers},${key}`)) {
             callback() 
@@ -3308,7 +3311,8 @@ export default class Views {
       })
     } else {
       const modifiers = "control"
-      ztoolkit.Keyboard.register((ev, data) => {
+      //ztoolkit.Keyboard.register((ev, data) => {
+      ztoolkit.Shortcut.register((ev, data) => {
         if (data.type === "keyup" && data.keyboard) {
           if (data.keyboard.equals(`${modifiers},${key}`)) {
             callback() 

--- a/src/ztoolkit.ts
+++ b/src/ztoolkit.ts
@@ -1,0 +1,60 @@
+import { config } from "../package.json";
+
+export { createZToolkit };
+
+function createZToolkit() {
+  // const _ztoolkit = new ZoteroToolkit();
+  /**
+   * Alternatively, import toolkit modules you use to minify the plugin size.
+   * You can add the modules under the `MyToolkit` class below and uncomment the following line.
+   */
+  const _ztoolkit = new MyToolkit();
+  initZToolkit(_ztoolkit);
+  return _ztoolkit;
+}
+
+function initZToolkit(_ztoolkit: ReturnType<typeof createZToolkit>) {
+  const env = __env__;
+  _ztoolkit.basicOptions.log.prefix = `[${config.addonName}]`;
+  _ztoolkit.basicOptions.log.disableConsole = env === "production";
+  _ztoolkit.UI.basicOptions.ui.enableElementJSONLog = __env__ === "development";
+  _ztoolkit.UI.basicOptions.ui.enableElementDOMLog = __env__ === "development";
+  _ztoolkit.basicOptions.debug.disableDebugBridgePassword =
+    __env__ === "development";
+  _ztoolkit.basicOptions.api.pluginID = config.addonID;
+  _ztoolkit.ProgressWindow.setIconURI(
+    "default",
+    `chrome://${config.addonRef}/content/icons/favicon.ico`,
+  );
+}
+
+import { BasicTool, UITool, ReaderTool, VirtualizedTableHelper, ProgressWindowHelper, ClipboardHelper, MenuManager, unregister, KeyboardManager } from "zotero-plugin-toolkit"
+
+
+class MyToolkit extends BasicTool {
+
+  UI: UITool;
+  VirtualizedTable: typeof VirtualizedTableHelper;
+  ProgressWindow: typeof ProgressWindowHelper;
+  Menu: MenuManager;
+  //Guide: typeof GuideHelper;
+  Shortcut: KeyboardManager;
+  Reader: ReaderTool;
+  Clipboard: typeof ClipboardHelper
+
+  constructor() {
+    super();
+    this.UI = new UITool(this);
+    this.VirtualizedTable = VirtualizedTableHelper;
+    this.ProgressWindow = ProgressWindowHelper;
+    this.Menu = new MenuManager(this);
+    //this.Guide = GuideHelper;
+    this.Shortcut = new KeyboardManager(this);
+    this.Reader = new ReaderTool(this);
+    this.Clipboard = ClipboardHelper 
+  }
+
+  unregisterAll() {
+    unregister(this);
+  }
+}


### PR DESCRIPTION
Fix the bug that when multiple zotero plugins installed first, papersgpt can't be started
Fix the bug that the papersgpt plugin can't chat pdf when the library of zotero-plugin-toolkit upgraded. 
Fix the icon of papersgpt can't be shown in ProgressWindow.
Fix the Clipborad can't be used.