### PR TITLE
Release papersgpt-v0.0.16

### DIFF
--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "papersgpt",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "Chat PDF in Zotero with ChatGPT, Gemini, Claude, DeepSeek, DeepSeek-R1-Distill-Llama, DeepSeek-R1-Distill-Qwen, Llama 3.2, QwQ-32B-Preview, Gemma, Mistral",
   "author": "Vincent",
   "icons": {

--- a/addon/updates.json
+++ b/addon/updates.json
@@ -3,7 +3,7 @@
     "papersgpt@papersgpt.com": {
       "updates": [
         {
-          "version": "0.0.15",
+          "version": "0.0.16",
           "update_link": "",
           "applications": {
             "gecko": {
@@ -13,7 +13,7 @@
           }
         },
         {
-          "version": "0.0.15",
+          "version": "0.0.16",
           "update_link": "",
           "applications": {
             "zotero": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "papersgpt",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "Chat PDF in Zotero with ChatGPT, Gemini, Claude, DeepSeek, DeepSeek-R1-Distill-Llama, DeepSeek-R1-Distill-Qwen, Llama 3.2, QwQ-32B-Preview, Gemma, Mistral",
   "config": {
     "addonName": "PapersGPT",

--- a/update.json
+++ b/update.json
@@ -3,7 +3,7 @@
     "papersgpt@papersgpt.com": {
       "updates": [
         {
-          "version": "0.0.15",
+          "version": "0.0.16",
           "update_link": "",
           "applications": {
             "gecko": {
@@ -12,7 +12,7 @@
           }
         },
         {
-          "version": "0.0.15",
+          "version": "0.0.16",
           "update_link": "",
           "applications": {
             "zotero": {

--- a/update.rdf
+++ b/update.rdf
@@ -5,7 +5,7 @@
       <rdf:Seq>
         <rdf:li>
           <rdf:Description>
-            <em:version>0.0.15</em:version>
+            <em:version>0.0.16</em:version>
             <em:targetApplication>
               <rdf:Description>
                 <em:id>zotero@chnm.gmu.edu</em:id>


### PR DESCRIPTION
1. Solve the issue that the latest models can not be acquired if network not well.
2. Fix a bug that context information may not be extracted if OpenAI API Key has no quota.