### PR TITLE
fix: fix security issue in Zotero.ts

### DIFF
--- a/src/modules/Meet/Zotero.ts
+++ b/src/modules/Meet/Zotero.ts
@@ -47,7 +47,15 @@ export function getClipboardText(): string {
  */
 async function selectedItems2documents(key: string) {
   const docs = ZoteroPane.getSelectedItems().map((item: Zotero.Item) => {
-    const text = JSON.stringify(item.toJSON());
+    // Only send the minimal, non-sensitive bibliographic fields needed for
+    // similarity search to external LLM services, instead of the full
+    // item.toJSON() payload (which can include tags, notes, relations,
+    // attachment paths and other private metadata).
+    const text = JSON.stringify({
+      title: item.getField("title"),
+      abstractNote: item.getField("abstractNote"),
+      date: item.getField("date")
+    });
     return new Document({
       pageContent: text.slice(0, 500),
       metadata: {


### PR DESCRIPTION
## Summary
Fix high severity security issue in `src/modules/Meet/Zotero.ts`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `src/modules/Meet/Zotero.ts:43` |
| **Assessment** | Likely exploitable |

**Description**: The plugin automatically extracts document content and metadata from Zotero items, then transmits this data to external LLM APIs (OpenAI, etc.) when not in local LLM mode. The code at lines 43-80 serializes full item data including potentially sensitive metadata, and the getRelatedText function routes this to external services without explicit user confirmation per operation.

## Evidence

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `src/modules/Meet/Zotero.ts`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*

<!-- orbis-meta: rule=V-001 scanner=multi_agent_ai -->
